### PR TITLE
Reversing the order of the flashCerts() and flashFirmware() functions

### DIFF
--- a/src/github.com/arduino-libraries/WiFi101-FirmwareUpdater/cli/main/winc1500-uploader.go
+++ b/src/github.com/arduino-libraries/WiFi101-FirmwareUpdater/cli/main/winc1500-uploader.go
@@ -91,14 +91,14 @@ func main() {
 		log.Fatalf("Programmer reports %d as maximum payload size (1024 is needed)", payloadSize)
 	}
 
-	if rootCertDir != "" || len(addresses) != 0 {
-		if err := flashCerts(); err != nil {
+	if firmwareFile != "" {
+		if err := flashFirmware(); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	if firmwareFile != "" {
-		if err := flashFirmware(); err != nil {
+	if rootCertDir != "" || len(addresses) != 0 {
+		if err := flashCerts(); err != nil {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
allows to use both commands in the same command line preventing certificates from being deleted when the firmware is flashed